### PR TITLE
NVDA 2022.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EnhancedFindDialog for NVDA 1.2.0
+# EnhancedFindDialog for NVDA 1.3.0
 Enhanced find dialog addon for NVDA, implementing search improvements:
 
 * search history
@@ -7,7 +7,7 @@ Enhanced find dialog addon for NVDA, implementing search improvements:
 * contextual information on searches
 
 ## Download
-Download the [Enhanced Find Dialog 1.2.0 addon](https://github.com/marlon-sousa/EnhancedFindDialog/releases/download/1.2.0/EnhancedFindDialog-1.2.0.nvda-addon)
+Download the [Enhanced Find Dialog 1.3.0 addon](https://github.com/marlon-sousa/EnhancedFindDialog/releases/download/1.3.0/EnhancedFindDialog-1.3.0.nvda-addon)
 
 ## Features
 

--- a/addon/doc/en/contributing.html
+++ b/addon/doc/en/contributing.html
@@ -5,7 +5,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 <link rel="stylesheet" type="text/css" href="../style.css" media="screen"/>
-<title>Enhanced find dialog for NVDA 0.0.3</title>
+<title>Enhanced find dialog for NVDA 1.3.0</title>
 </head>
 <body>
 <h1>Contributing</h1>

--- a/addon/globalPlugins/EnhancedFindDialog/guiHelper.py
+++ b/addon/globalPlugins/EnhancedFindDialog/guiHelper.py
@@ -8,6 +8,7 @@ import addonHandler
 import config
 import core
 import cursorManager
+from gui import contextHelp
 import wx
 
 # this addon mostly complements NVDA functionalities.
@@ -64,13 +65,18 @@ def setConfig(profile, key, value):
 	profile[module][key] = value
 
 
-class EnhancedFindDialog(wx.Dialog):
+class EnhancedFindDialog(
+	contextHelp.ContextHelpMixin,
+	wx.Dialog
+):
 	"""A dialog used to specify text to find in a cursor manager.
 	"""
 
+	helpId = "SearchingForText"
+
 	def __init__(self, parent, cursorManager, profile, searchEntries):
 		# Translators: Title of a dialog to find text.
-		super(EnhancedFindDialog, self).__init__(parent, wx.ID_ANY, __("Find"))
+		super().__init__(parent, title=__("Find"))
 		# if checkboxes change during this dialog we need to save the profile with the new values
 		self._mustSaveProfile = False
 		# Have a copy of the active cursor manager, as this is needed later for finding text.
@@ -113,6 +119,7 @@ class EnhancedFindDialog(wx.Dialog):
 		self.SetSizer(mainSizer)
 		self.CentreOnScreen()
 		self.findTextField.SetFocus()
+
 
 	def updateSearchEntries(self, searchEntries, currentSearchTerm):
 		if not currentSearchTerm:

--- a/buildVars.py
+++ b/buildVars.py
@@ -20,7 +20,7 @@ addon_info = {
 	"addon_description" : _("""This addon introduces improvements to the NVDA find dialog.
 It is now possible to have your previous searches history available on a list during the NVDA session, which will enable you to quickly select and search for previous searched terms."""),
 	# version
-	"addon_version" : "1.2.0",
+	"addon_version" : "1.3.0",
 	# Author(s)
 	"addon_author" : u"Marlon Brandão de Sousa <marlon.bsousa@gmail.com>",
 	# URL for the add-on documentation support
@@ -28,9 +28,9 @@ It is now possible to have your previous searches history available on a list du
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion" : "2021.1",
+	"addon_minimumNVDAVersion" : "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2021.1",
+	"addon_lastTestedNVDAVersion" : "2022.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
In this pr, we make the addon compatible with NVDA 2022.2.

We also fix a bug where a dialog saying that searched text is not found appears incorrectly when search wrap is active and find next / find previous are used: if content has only one instance of the searched text and the cursor is on this text, a dialog saying that the searched text was not found would appear. Now, we make the wrapped search, beep and put the cursor back on that same selection.