### PR TITLE
Fix search previous functionality not working properly when the text field was empty

### DIFF
--- a/addon/globalPlugins/EnhancedFindDialog/cursorManagerHelper.py
+++ b/addon/globalPlugins/EnhancedFindDialog/cursorManagerHelper.py
@@ -54,7 +54,7 @@ def patchCursorManager():
 
 
 
-def script_enhancedFind(self,gesture):
+def script_enhancedFind(self, gesture, reverse=False):
 	# #8566: We need this to be a modal dialog, but it mustn't block this script.
 	def run():
 		# get the active profile and send that to the find dialog
@@ -62,7 +62,7 @@ def script_enhancedFind(self,gesture):
 		profile = config.conf.getActiveProfile()
 
 		gui.mainFrame.prePopup()
-		d = guiHelper.EnhancedFindDialog(gui.mainFrame, self, profile, self._searchEntries)
+		d = guiHelper.EnhancedFindDialog(gui.mainFrame, self, profile, self._searchEntries, reverse)
 		d.ShowModal()
 		gui.mainFrame.postPopup()
 	wx.CallAfter(run)
@@ -82,7 +82,7 @@ def script_enhancedFindNext(self,gesture):
 
 def script_EnhancedFindPrevious(self,gesture):
 	if not self._searchEntries:
-		self.script_find(gesture)
+		self.script_find(gesture, reverse=True)
 		return
 	doFindText(
 		self,

--- a/addon/globalPlugins/EnhancedFindDialog/guiHelper.py
+++ b/addon/globalPlugins/EnhancedFindDialog/guiHelper.py
@@ -75,9 +75,10 @@ class EnhancedFindDialog(
 
 	helpId = "SearchingForText"
 
-	def __init__(self, parent, cursorManager, profile, searchEntries):
+	def __init__(self, parent, cursorManager, profile, searchEntries, reverseSearch):
 		# Translators: Title of a dialog to find text.
 		super().__init__(parent, title=__("Find"))
+		self.reverseSearch = reverseSearch
 		# if checkboxes change during this dialog we need to save the profile with the new values
 		self._mustSaveProfile = False
 		# Have a copy of the active cursor manager, as this is needed later for finding text.
@@ -163,7 +164,7 @@ class EnhancedFindDialog(
 
 		# We must use core.callLater rather than wx.CallLater to ensure that the callback runs within NVDA's core pump.
 		# If it didn't, and it directly or indirectly called wx.Yield, it could start executing NVDA's core pump from within the yield, causing recursion.
-		core.callLater(100, cursorManagerHelper.doFindText, self.activeCursorManager, text, caseSensitive=caseSensitive, searchWrap = searchWrap)
+		core.callLater(100, cursorManagerHelper.doFindText, self.activeCursorManager, text, caseSensitive=caseSensitive, searchWrap = searchWrap, reverse = self.reverseSearch)
 		self.Destroy()
 
 	def onCancel(self, evt):


### PR DESCRIPTION
Fix search previous functionality not working properly when the text field was empty.

Also fix reverse search with search wrap searching forward if the text field is empty.

Fixes issue #19.