### PR TITLE
Update the pipeline to generate the English README.md correctly.

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -117,12 +117,16 @@ def createAddonHelp(dir):
 		cssPath = os.path.join(docsDir, "style.css")
 		cssTarget = env.Command(cssPath, "style.css", Copy("$TARGET", "$SOURCE"))
 		env.Depends(addon, cssTarget)
-	if os.path.isfile("readme.tpl.md"):
-		expandFile("readme.tpl.md")
-		readmePath = os.path.join(docsDir, "en", "readme.md")
-		readmeTarget = env.Command(readmePath, "readme.md", Copy("$TARGET", "$SOURCE"))
-		env.Depends(addon, readmeTarget)
-	
+
+	# Fix case if README.md is in uppercase, in this case the pipeline failed to build the english documentation because it was running on a Linux system.
+	for filename in ("readme", "README"):
+		if os.path.isfile(f"{filename}.tpl.md"):
+			expandFile(f"{filename}.tpl.md")
+			readmePath = os.path.join(docsDir, "en", "readme.md")
+			readmeTarget = env.Command(readmePath, f"{filename}.md", Copy("$TARGET", "$SOURCE"))
+			env.Depends(addon, readmeTarget)
+			break
+
 	if os.path.isfile("contributing.md"):
 		contribPath = os.path.join(docsDir, "en", "contributing.md")
 		contribTarget = env.Command(contribPath, "contributing.md", Copy("$TARGET", "$SOURCE"))


### PR DESCRIPTION
This was caused by the build pipeline running on a Linux system (Github actions). On Linux, the system considers filenames like readme.md (all lower case) and README.md (upper case) different. The fix was to include both possibilities when generating the addon. I also considered renaming the file but I think Github only shows the README.md file (all in upper case) on the page.

Thanks to CyrilleB79 on issue #21 for the bug report.