### PR TITLE
Update style.css as per add-on template

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -20,7 +20,7 @@ addon_info = {
 	"addon_description" : _("""This addon introduces improvements to the NVDA find dialog.
 It is now possible to have your previous searches history available on a list during the NVDA session, which will enable you to quickly select and search for previous searched terms."""),
 	# version
-	"addon_version" : "1.4.1",
+	"addon_version" : "1.4.2",
 	# Author(s)
 	"addon_author" : u"Marlon Brandão de Sousa <marlon.bsousa@gmail.com>",
 	# URL for the add-on documentation support

--- a/style.css
+++ b/style.css
@@ -1,8 +1,6 @@
 ﻿@charset "utf-8";
 body { 
 font-family : Verdana, Arial, Helvetica, Sans-serif;
-color : #FFFFFF;
-background-color : #000000;
 line-height: 1.2em;
 } 
 h1, h2 {text-align: center}
@@ -26,5 +24,3 @@ a { text-decoration : underline;
 text-decoration : none; 
 }
 a:focus, a:hover {outline: solid}
-:link {color: #0000FF;
-background-color: #FFFFFF}


### PR DESCRIPTION
### Issue
The doc of this add-on is using inverted color scheme. This inverted color scheme has been removed from the add-on template; see https://github.com/nvdaaddons/AddonTemplate/issues/4 and https://github.com/nvdaaddons/AddonTemplate/pull/8 for explanations.
Short story: it's better to let each visually impaired person his/her preferred color scheme.

### Solution
Update style.css file as per add-on template.
