### PR TITLE
update CI to the latest version of the upload-artifact action (v4)

### DIFF
--- a/.github/workflows/pr-addon-artifact.yml
+++ b/.github/workflows/pr-addon-artifact.yml
@@ -26,7 +26,7 @@ jobs:
           rm -f *.nvda-addon || true
           scons
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: addon
           path: "*.nvda-addon"


### PR DESCRIPTION
According to the [actions/upload-artifact documentation on Github](https://github.com/[actions/upload-artifact), v3 of the action was deprecated on November 30, 2024. This broke our CI/CD pipeline as it could not upload artifacts of compiled addon versions anymore. This pull request updates the `uses:` line of actions/upload-artifact, to use the version 4 to make CI/CD builds work again.