### PR TITLE
Search to the last possible match of regexp in reverse search

### DIFF
--- a/addon/globalPlugins/EnhancedFindDialog/cursorManagerHelper.py
+++ b/addon/globalPlugins/EnhancedFindDialog/cursorManagerHelper.py
@@ -222,10 +222,17 @@ def find(cursorManager, searchTerm, info, reverse, caseSensitive):
 def findRegexp(self, text, reverse=False):
 	if reverse:
 		inText = self._getTextRange(0, self._startOffset)
-		matches = list(re.finditer(text, inText, re.UNICODE))
-		if not matches:
-			return False
-		m = matches[-1]
+		curOffset = 0
+		endOffset = self._startOffset
+		m = None
+		while curOffset < self._startOffset:
+			tempMatch = re.search(text, inText[curOffset:endOffset + 1], re.UNICODE)
+			if not tempMatch:
+				break
+
+			m = tempMatch
+			matchLocation = curOffset + m.start()
+			curOffset += m.start() + 1
 	else:
 		inText = self._getTextRange(self._startOffset + 1, self._getStoryLength())
 		m = re.search(text, inText, re.UNICODE)
@@ -235,7 +242,7 @@ def findRegexp(self, text, reverse=False):
 	converter = textUtils.getOffsetConverter(self.encoding)(inText)
 
 	if reverse:
-		offset = converter.strToEncodedOffsets(m.start())
+		offset = converter.strToEncodedOffsets(matchLocation)
 	else:
 		offset = self._startOffset + 1 + converter.strToEncodedOffsets(m.start())
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,7 +30,7 @@ It is now possible to have your previous searches history available on a list du
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion" : "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2024.1",
+	"addon_lastTestedNVDAVersion" : "2025.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
closes #42 .

This is an attempt to fix issue #42 by searching all possible matches of a regexp. When a match is found, it tries to search from the character following the match onto the start offset,  to fix the greedy case described on the issue. This currently needs more testing to check if this solution works with more regular expressions, but for the described test case found on  the issue it works, so I am marking in draft status for now.